### PR TITLE
fix: changed address to addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Queries a given domain and parses the results to retrieve openattestation docume
 
 #### Parameters
 
--   `domain` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** e.g: "ruijiechow.com", "documentstores.openattestation.com"
+-   `domain` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** e.g: "example.openattestation.com"
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Takes a DNS-TXT Record set and returns openattestation document store records if
 
 #### Parameters
 
--   `recordSet` **Answer** Refer to tests for examples (optional, default `[]`)
+-   `recordSet` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IDNSRecord>** Refer to tests for examples (optional, default `[]`)
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;OpenAttestationDNSTextRecord>** 
 
@@ -35,11 +35,11 @@ Queries a given domain and parses the results to retrieve openattestation docume
 #### Examples
 
 ```javascript
-> getDocumentStoreRecords("documentstores.openattestation.com")
+> getDocumentStoreRecords("example.openattestation.com")
 > [ { type: 'openatts',
 net: 'ethereum',
 netId: '3',
-address: '0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC',
+addr: '0x2f60375e8144e16Adf1979936301D8341D58C36C',
 dnssec: true } ]
 ```
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,7 +4,7 @@ const sampleDnsTextRecord = {
   type: "openatts",
   net: "ethereum",
   netId: "3",
-  address: "0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"
+  addr: "0x2f60375e8144e16Adf1979936301D8341D58C36C"
 };
 
 describe("getCertStoreRecords", () => {
@@ -12,11 +12,11 @@ describe("getCertStoreRecords", () => {
     type: "openatts",
     net: "ethereum",
     netId: "3",
-    dnssec: true,
-    address: "0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"
+    dnssec: false,
+    addr: "0x2f60375e8144e16Adf1979936301D8341D58C36C"
   };
   test("it should work", async () => {
-    expect(await getDocumentStoreRecords("ruijiechow.com")).toStrictEqual([sampleDnsTextRecordWithDnssec]);
+    expect(await getDocumentStoreRecords("example.openattestation.com")).toStrictEqual([sampleDnsTextRecordWithDnssec]);
   });
 
   test("it should return an empty array if there is no openatts record", async () => {
@@ -32,10 +32,10 @@ describe("parseDnsResults", () => {
   test("it should return one record in an array if there is one openatts record", () => {
     const sampleRecord = [
       {
-        name: "ruijiechow.com.",
+        name: "example.openattestation.com.",
         type: 16,
         TTL: 110,
-        data: '"openatts net=ethereum netId=3 address=0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"'
+        data: '"openatts net=ethereum netId=3 addr=0x2f60375e8144e16Adf1979936301D8341D58C36C"'
       }
     ];
     expect(parseDnsResults(sampleRecord)).toStrictEqual([sampleDnsTextRecord]);
@@ -43,10 +43,10 @@ describe("parseDnsResults", () => {
   test("it should not mangle records with = in it", () => {
     const sampleRecord = [
       {
-        name: "ruijiechow.com.",
+        name: "example.openattestation.com.",
         type: 16,
         TTL: 110,
-        data: '"openatts net=ethereum=classic netId=3 address=0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"'
+        data: '"openatts net=ethereum=classic netId=3 addr=0x2f60375e8144e16Adf1979936301D8341D58C36C"'
       }
     ];
     expect(parseDnsResults(sampleRecord)).toStrictEqual([
@@ -54,35 +54,35 @@ describe("parseDnsResults", () => {
         type: "openatts",
         net: "ethereum=classic",
         netId: "3",
-        address: "0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"
+        addr: "0x2f60375e8144e16Adf1979936301D8341D58C36C"
       }
     ]);
   });
   test("it should return two record items if there are two openatts record", () => {
     const sampleRecord = [
       {
-        name: "ruijiechow.com.",
+        name: "example.openattestation.com.",
         type: 16,
         TTL: 110,
-        data: '"openatts net=ethereum netId=3 address=0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"'
+        data: '"openatts net=ethereum netId=3 addr=0x2f60375e8144e16Adf1979936301D8341D58C36C"'
       },
       {
-        name: "ruijiechow.com.",
+        name: "example.openattestation.com.",
         type: 16,
         TTL: 110,
-        data: '"openatts net=ethereum netId=1 address=0x007d40224f6562461633ccfbaffd359ebb2fc9ba"'
+        data: '"openatts net=ethereum netId=1 addr=0x007d40224f6562461633ccfbaffd359ebb2fc9ba"'
       }
     ];
 
     expect(parseDnsResults(sampleRecord)).toStrictEqual([
       {
-        address: "0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC",
+        addr: "0x2f60375e8144e16Adf1979936301D8341D58C36C",
         net: "ethereum",
         netId: "3",
         type: "openatts"
       },
       {
-        address: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
+        addr: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
         net: "ethereum",
         netId: "1",
         type: "openatts"

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ interface OpenAttestationDNSTextRecord {
   type: RecordTypes;
   net: BlockchainNetwork; // key names are directly lifted from the dns-txt record format
   netId: EthereumNetworkId; // they are abbreviated because of 255 char constraint on dns-txt records
-  address: EthereumAddress;
+  addr: EthereumAddress;
   dnssec: boolean;
 }
 
@@ -35,7 +35,7 @@ interface IDNSQueryResponse {
 
 /**
  * Returns true for strings that are openattestation records
- * @param txtDataString e.g: '"openatts net=ethereum netId=3 address=0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"'
+ * @param txtDataString e.g: '"openatts net=ethereum netId=3 addr=0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"'
  */
 const isOpenAttestationRecord = (txtDataString: string) => {
   return txtDataString.startsWith("openatts");
@@ -59,7 +59,7 @@ const addKeyValuePairToObject = (obj: any, keyValuePair: string): any => {
 
 /**
  * Parses one openattestation DNS-TXT record and turns it into an OpenAttestationsDNSTextRecord object
- * @param record e.g: '"openatts net=ethereum netId=3 address=0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"'
+ * @param record e.g: '"openatts net=ethereum netId=3 addr=0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC"'
  */
 const parseOpenAttestationRecord = (record: string): OpenAttestationDNSTextRecord => {
   trace(`Parsing record: ${record}`);
@@ -97,11 +97,11 @@ export const parseDnsResults = (recordSet: IDNSRecord[] = []): OpenAttestationDN
  * Queries a given domain and parses the results to retrieve openattestation document store records if any
  * @param domain e.g: "ruijiechow.com", "documentstores.openattestation.com"
  * @example 
- * > getDocumentStoreRecords("documentstores.openattestation.com")
+ * > getDocumentStoreRecords("example.openattestation.com")
  * > [ { type: 'openatts',
     net: 'ethereum',
     netId: '3',
-    address: '0x0c9d5E6C766030cc6f0f49951D275Ad0701F81EC',
+    addr: '0x2f60375e8144e16Adf1979936301D8341D58C36C',
     dnssec: true } ]
  */
 export const getDocumentStoreRecords = async (domain: string): Promise<OpenAttestationDNSTextRecord[]> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export const parseDnsResults = (recordSet: IDNSRecord[] = []): OpenAttestationDN
 
 /**
  * Queries a given domain and parses the results to retrieve openattestation document store records if any
- * @param domain e.g: "ruijiechow.com", "documentstores.openattestation.com"
+ * @param domain e.g: "example.openattestation.com"
  * @example 
  * > getDocumentStoreRecords("example.openattestation.com")
  * > [ { type: 'openatts',


### PR DESCRIPTION
Previously it was documented that the key name should be addr but the implementation returned address, have updated tests and documentation to reflect this.

Reason for using addr instead of address is to keep in mind that there's a 255 char limit on DNS TXT records and we need to be prudent with the verbosity of the record